### PR TITLE
ゲームの状態更新を UpdateMonad に包んで記述する

### DIFF
--- a/Util/Misc.fs
+++ b/Util/Misc.fs
@@ -167,6 +167,9 @@ module UpdateMonad =
         else this.Zero()
       in loop ()
 
+  let run g (UM f) = f g |> snd
+  let up u = UM (fun _ -> (u, ()))
+
 [<AutoOpen>]
 module UpdateMonadSyntax =
   let update = UpdateMonad.UpdateBuilder()


### PR DESCRIPTION
- 意外と影響範囲は小さかった。
- 既に `async` に感染しているのでやりづらかった。
  - AsyncUpdateMonad を用意すべき？
## 参考
- [Update モナドを使った F# における状態を持った計算](https://github.com/Gab-km/update-monads_jp/blob/master/update-monads-jp.rst)
